### PR TITLE
Fixed dupe commit hash

### DIFF
--- a/.github/workflows/_npm_gh_auto_release.yaml
+++ b/.github/workflows/_npm_gh_auto_release.yaml
@@ -16,9 +16,6 @@ on:
         required: false
         type: boolean
         default: false
-      commit_hash:
-        required: false
-        type: string
 
 jobs:
   run:


### PR DESCRIPTION
It already appears earlier:
https://github.com/SparkHire/.github/blob/3076f26c13d762643310aa316784b99d96b99a99/.github/workflows/_npm_gh_auto_release.yaml#L6-L8


This is breaking PR github actions in our react-v3 repos with [this error:](https://github.com/SparkHire/react-v3-components/actions/runs/22314539280?pr=171)
```
[Invalid workflow file: .github/workflows/pull-request.yaml#L60](https://github.com/SparkHire/react-v3-components/actions/runs/22314539280/workflow)
error parsing called workflow
".github/workflows/pull-request.yaml"
-> "SparkHire/.github/.github/workflows/_npm_gh_auto_release.yaml@main" (source branch with sha:c1334e9e109d17721436bcb5fce7b3c45dc03088)
: (Line: 19, Col: 7): 'commit_hash' is already defined
```