### PR TITLE
Added subject input that defaults to "GitHub"

### DIFF
--- a/.github/workflows/_aws_perform_ecs_release.yaml
+++ b/.github/workflows/_aws_perform_ecs_release.yaml
@@ -189,6 +189,7 @@ jobs:
 
   deploy:
     needs: get-services
+    name: deploy-${{ matrix.service }}
     if: ${{ needs.get-services.outputs.services != '[]' && needs.get-services.outputs.services != '' }}
     strategy:
       matrix:

--- a/.github/workflows/_notify_sns.yaml
+++ b/.github/workflows/_notify_sns.yaml
@@ -11,6 +11,11 @@ on:
         description: 'Type of notification (info, warning, alarm, emergency)'
         required: true
         type: string
+      subject:
+        description: 'The subject of the message'
+        required: false
+        type: string
+        default: 'GitHub'
       message:
         description: 'The notification message'
         required: true
@@ -58,6 +63,7 @@ jobs:
           TOPIC_EMERGENCY: ${{ secrets.AWS_SNS_TOPIC_EMERGENCY_ARN }}
           NOTIFICATION_TYPE: ${{ inputs.type }}
           NOTIFICATION_MESSAGE: ${{ inputs.message }}
+          NOTIFICATION_SUBJECT: ${{ inputs.subject }}
         run: |
           TYPE=$(echo "$NOTIFICATION_TYPE" | tr '[:lower:]' '[:upper:]')
           case "$TYPE" in
@@ -77,4 +83,4 @@ jobs:
           fi
 
           echo "Publishing notification of type $TYPE to SNS topic..."
-          aws sns publish --topic-arn "$TOPIC_ARN" --message "$NOTIFICATION_MESSAGE"
+          aws sns publish --topic-arn "$TOPIC_ARN" --message "$NOTIFICATION_MESSAGE" --subject "$NOTIFICATION_SUBJECT"


### PR DESCRIPTION
This pull request enhances the `_notify_sns.yaml` GitHub Actions workflow by adding support for an optional notification subject when publishing messages to AWS SNS. This allows for more informative and customizable SNS notifications.

**Improvements to notification configuration:**

* Added a new optional `subject` input to the workflow, with a default value of `'GitHub'`, allowing users to specify a subject for the SNS notification.

**Enhancements to message publishing:**

* Passed the `subject` input value as an environment variable (`NOTIFICATION_SUBJECT`) to the workflow job steps.
* Updated the `aws sns publish` command to include the `--subject` parameter, ensuring the subject is used in the published notification.