### PR TITLE
Add deregisteredAt to task def omit and code deployment abort

### DIFF
--- a/.github/workflows/_aws_perform_code_deploy.yaml
+++ b/.github/workflows/_aws_perform_code_deploy.yaml
@@ -251,4 +251,9 @@ jobs:
           done
 
           echo "Error: Deployment monitoring timed out after 15 minutes."
+          echo "Stopping deployment $DEPLOYMENT_ID and initiating rollback..."
+          aws deploy stop-deployment \
+            --region "${{ inputs.aws_region }}" \
+            --deployment-id "$DEPLOYMENT_ID" \
+            --auto-rollback-enabled || echo "Warning: Failed to stop deployment."
           exit 1

--- a/.github/workflows/_aws_update_task_definition.yaml
+++ b/.github/workflows/_aws_update_task_definition.yaml
@@ -74,7 +74,7 @@ jobs:
         id: render-task-def
         run: |
           # Remove fields that prevent registering a new task definition
-          jq 'del(.taskDefinitionArn, .revision, .status, .requiresAttributes, .compatibilities, .registeredAt, .registeredBy)' current-task-def.json > temp-task-def.json
+          jq 'del(.taskDefinitionArn, .revision, .status, .requiresAttributes, .compatibilities, .registeredAt, .registeredBy, .deregisteredAt)' current-task-def.json > temp-task-def.json
 
           # Update the specified containers' image tags
           jq --arg tag "${{ inputs.image_sha }}" --arg containers "${{ inputs.container_update_tag }}" '


### PR DESCRIPTION
## Summary
This pull request introduces improvements to our AWS deployment and ECS task definition workflows. The main focus is on enhancing deployment reliability by enabling automatic rollback on deployment timeouts, and ensuring task definitions are properly sanitized before registration.

**AWS Deployment Reliability:**

* Updated the deployment monitoring script in `.github/workflows/_aws_perform_code_deploy.yaml` to automatically stop the deployment and initiate a rollback if monitoring times out after 15 minutes, improving failure recovery.

**ECS Task Definition Registration:**

* Modified the task definition rendering step in `.github/workflows/_aws_update_task_definition.yaml` to also remove the `.deregisteredAt` field, preventing issues when registering new task definitions.

## Notes
- Something weird going on with current staging task def during the update. This should fix it hopefully
<img width="1542" height="94" alt="image" src="https://github.com/user-attachments/assets/97424c74-eae7-4fb6-9e29-9fe3f52a3ae1" />

