### PR TITLE
[Infra] Implemented AWS ECS rollback workflow

### DIFF
--- a/.github/workflows/_aws_get_ecs_services.yaml
+++ b/.github/workflows/_aws_get_ecs_services.yaml
@@ -1,0 +1,174 @@
+name: Get ECS Services
+
+on:
+  workflow_call:
+    inputs:
+      environment:
+        description: 'The environment being deployed to'
+        required: true
+        type: string
+      aws_account_id:
+        description: 'The AWS account ID of the cluster'
+        required: true
+        type: string
+      aws_region:
+        description: 'The AWS region of the cluster'
+        required: true
+        type: string
+      ecs_cluster:
+        description: 'The ECS cluster name or ARN to target (optional if ecs_cluster_name_tag is provided). Supports {aws_region}, {region}, and {environment} template replacements. If a plain name is provided, the full ARN will be constructed using aws_account_id and aws_region.'
+        required: false
+        type: string
+      ecs_cluster_name_tag:
+        description: 'The ECS cluster Name tag to search for (optional if ecs_cluster is provided). Supports {region} and {environment} template replacements.'
+        required: false
+        type: string
+      exclude_tag_key:
+        description: 'The tag key used to filter out services (e.g. ExcludeFromRelease)'
+        required: false
+        type: string
+      exclude_tag_value:
+        description: 'The tag value used to filter out services (e.g. true)'
+        required: false
+        type: string
+      always_exclude_tag_key:
+        description: 'The tag key used to always filter out services (e.g. AlwaysExcludeFromRelease)'
+        required: false
+        type: string
+      force_release:
+        description: 'Force release even if the service is marked with the ExcludeFromRelease tag'
+        required: false
+        type: string
+        default: 'No'
+    outputs:
+      services:
+        description: 'JSON stringified array of ECS service ARNs'
+        value: ${{ jobs.get-services.outputs.services }}
+      excluded_services:
+        description: 'JSON stringified array of ECS service ARNs excluded by tag filters'
+        value: ${{ jobs.get-services.outputs.excluded_services }}
+      resolved_cluster:
+        description: 'Resolved ECS cluster ARN'
+        value: ${{ jobs.get-services.outputs.resolved_cluster }}
+
+permissions:
+  id-token: write
+  contents: read
+
+jobs:
+  get-services:
+    runs-on: ${{ vars.DEFAULT_RUNNER }}
+    environment: ${{ inputs.environment }}
+    outputs:
+      services: ${{ steps.fetch.outputs.services }}
+      excluded_services: ${{ steps.fetch.outputs.excluded_services }}
+      resolved_cluster: ${{ steps.resolve-cluster.outputs.resolved_cluster }}
+    steps:
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v6
+        with:
+          aws-region: ${{ inputs.aws_region }}
+          role-to-assume: ${{ secrets.AWS_ROLE }}
+
+      - name: Resolve Cluster
+        id: resolve-cluster
+        run: |
+          CLUSTER_INPUT="${{ inputs.ecs_cluster }}"
+          CLUSTER_TAG_INPUT="${{ inputs.ecs_cluster_name_tag }}"
+
+          if [ -n "$CLUSTER_TAG_INPUT" ]; then
+            CLUSTER_TAG_INPUT=$(echo "$CLUSTER_TAG_INPUT" | sed "s/{aws_region}/${{ inputs.aws_region }}/g" | sed "s/{region}/${{ inputs.aws_region }}/g" | sed "s/{environment}/${{ inputs.environment }}/g")
+          fi
+
+          if [ -n "$CLUSTER_INPUT" ]; then
+            CLUSTER_INPUT=$(echo "$CLUSTER_INPUT" | sed "s/{aws_region}/${{ inputs.aws_region }}/g" | sed "s/{region}/${{ inputs.aws_region }}/g" | sed "s/{environment}/${{ inputs.environment }}/g")
+            if [[ "$CLUSTER_INPUT" != arn:* ]]; then
+              CLUSTER_INPUT="arn:aws:ecs:${{ inputs.aws_region }}:${{ inputs.aws_account_id }}:cluster/$CLUSTER_INPUT"
+            fi
+            echo "Using provided ECS cluster: $CLUSTER_INPUT"
+            echo "resolved_cluster=$CLUSTER_INPUT" >> $GITHUB_OUTPUT
+          elif [ -n "$CLUSTER_TAG_INPUT" ]; then
+            echo "Searching for ECS cluster by Name tag: $CLUSTER_TAG_INPUT..."
+
+            CLUSTER_ARNS=$(aws ecs list-clusters --query "clusterArns" --output text)
+
+            RESOLVED=""
+            for ARN in $CLUSTER_ARNS; do
+              TAG_VAL=$(aws ecs list-tags-for-resource --resource-arn "$ARN" --query "tags[?key=='Name'].value" --output text 2>/dev/null || echo "")
+              if [ "$TAG_VAL" = "$CLUSTER_TAG_INPUT" ]; then
+                RESOLVED="$ARN"
+                break
+              fi
+            done
+
+            if [ -z "$RESOLVED" ]; then
+              RESOLVED=$(aws resourcegroupstaggingapi get-resources \
+                --region "${{ inputs.aws_region }}" \
+                --resource-type-filters "ecs:cluster" \
+                --tag-filters "Key=Name,Values=$CLUSTER_TAG_INPUT" \
+                --query "ResourceTagMappingList[0].ResourceARN" \
+                --output text 2>/dev/null || echo "")
+            fi
+
+            if [ -z "$RESOLVED" ] || [ "$RESOLVED" = "None" ]; then
+              echo "Error: Could not find any ECS Cluster with tag Name=$CLUSTER_TAG_INPUT in region ${{ inputs.aws_region }}"
+              exit 1
+            fi
+
+            echo "Resolved ECS cluster ARN: $RESOLVED"
+            echo "resolved_cluster=$RESOLVED" >> $GITHUB_OUTPUT
+          else
+            echo "Error: Neither ecs_cluster nor ecs_cluster_name_tag input was provided."
+            exit 1
+          fi
+
+      - name: Fetch Services
+        id: fetch
+        run: |
+          RESOLVED_CLUSTER="${{ steps.resolve-cluster.outputs.resolved_cluster }}"
+          if ! SERVICES_ARNS=$(aws ecs list-services --cluster "$RESOLVED_CLUSTER" --query "serviceArns" --output text 2>&1); then
+            echo "Failed to fetch services:"
+            exit 1
+          fi
+
+          echo "Service arns: $SERVICES_ARNS"
+
+          ALL_SERVICES="[]"
+          EXCLUDED_SERVICES="[]"
+          for ARN in $SERVICES_ARNS; do
+            ALL_SERVICES=$(echo "$ALL_SERVICES" | jq --arg arn "$ARN" '. + [$arn]')
+            EXCLUDE=false
+            FORCE_EXCLUDE=false
+            if [ -n "${{ inputs.exclude_tag_key }}" ]; then
+              TAG_VALUE=$(aws ecs list-tags-for-resource --resource-arn "$ARN" --query "tags[?key=='${{ inputs.exclude_tag_key }}'].value" --output text 2>/dev/null || echo "")
+
+              if [ -n "${{ inputs.exclude_tag_value }}" ]; then
+                if [ "$TAG_VALUE" = "${{ inputs.exclude_tag_value }}" ]; then
+                  EXCLUDE=true
+                fi
+              elif [ -n "$TAG_VALUE" ]; then
+                EXCLUDE=true
+              fi
+            fi
+
+            if [ -n "${{ inputs.always_exclude_tag_key }}" ]; then
+              ALWAYS_EXCLUDE_TAG_VALUE=$(aws ecs list-tags-for-resource --resource-arn "$ARN" --query "tags[?key=='${{ inputs.always_exclude_tag_key }}'].value" --output text 2>/dev/null || echo "")
+              if [ -n "$ALWAYS_EXCLUDE_TAG_VALUE" ]; then
+                FORCE_EXCLUDE=true
+              fi
+            fi
+
+            if [ "$FORCE_EXCLUDE" = true ] || { [ "$EXCLUDE" = true ] && [ "${{ inputs.force_release }}" != "Yes" ]; }; then
+              if [ "$FORCE_EXCLUDE" = true ]; then
+                echo "Excluding service $ARN based on always-exclude tag filter."
+              else
+                echo "Excluding service $ARN based on tag filter."
+              fi
+              EXCLUDED_SERVICES=$(echo "$EXCLUDED_SERVICES" | jq --arg arn "$ARN" '. + [$arn]')
+            fi
+          done
+
+          COMPACT_ALL=$(echo "$ALL_SERVICES" | jq -c '.')
+          COMPACT_EXCLUDED=$(echo "$EXCLUDED_SERVICES" | jq -c '.')
+          echo "services=$COMPACT_ALL" >> $GITHUB_OUTPUT
+          echo "excluded_services=$COMPACT_EXCLUDED" >> $GITHUB_OUTPUT

--- a/.github/workflows/_aws_perform_ecs_release.yaml
+++ b/.github/workflows/_aws_perform_ecs_release.yaml
@@ -65,127 +65,18 @@ permissions:
 
 jobs:
   get-services:
-    runs-on: ${{ vars.DEFAULT_RUNNER }}
-    environment: ${{ inputs.environment }}
-    outputs:
-      services: ${{ steps.fetch.outputs.services }}
-      excluded_services: ${{ steps.fetch.outputs.excluded_services }}
-      resolved_cluster: ${{ steps.resolve-cluster.outputs.resolved_cluster }}
-    steps:
-      - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v6
-        with:
-          aws-region: ${{ inputs.aws_region }}
-          role-to-assume: ${{ secrets.AWS_ROLE }}
-
-      - name: Resolve Cluster
-        id: resolve-cluster
-        run: |
-          CLUSTER_INPUT="${{ inputs.ecs_cluster }}"
-          CLUSTER_TAG_INPUT="${{ inputs.ecs_cluster_name_tag }}"
-
-          # Handle handlebars-style template replacements
-          if [ -n "$CLUSTER_TAG_INPUT" ]; then
-            CLUSTER_TAG_INPUT=$(echo "$CLUSTER_TAG_INPUT" | sed "s/{aws_region}/${{ inputs.aws_region }}/g" | sed "s/{region}/${{ inputs.aws_region }}/g" | sed "s/{environment}/${{ inputs.environment }}/g")
-          fi
-
-          if [ -n "$CLUSTER_INPUT" ]; then
-            CLUSTER_INPUT=$(echo "$CLUSTER_INPUT" | sed "s/{aws_region}/${{ inputs.aws_region }}/g" | sed "s/{region}/${{ inputs.aws_region }}/g" | sed "s/{environment}/${{ inputs.environment }}/g")
-            # If not already an ARN, construct the full ECS cluster ARN
-            if [[ "$CLUSTER_INPUT" != arn:* ]]; then
-              CLUSTER_INPUT="arn:aws:ecs:${{ inputs.aws_region }}:${{ inputs.aws_account_id }}:cluster/$CLUSTER_INPUT"
-            fi
-            echo "Using provided ECS cluster: $CLUSTER_INPUT"
-            echo "resolved_cluster=$CLUSTER_INPUT" >> $GITHUB_OUTPUT
-          elif [ -n "$CLUSTER_TAG_INPUT" ]; then
-            echo "Searching for ECS cluster by Name tag: $CLUSTER_TAG_INPUT..."
-
-            # Retrieve all cluster ARNs first
-            CLUSTER_ARNS=$(aws ecs list-clusters --query "clusterArns" --output text)
-
-            RESOLVED=""
-            for ARN in $CLUSTER_ARNS; do
-              # Describe tags for each cluster to find Name tag matching CLUSTER_TAG_INPUT
-              TAG_VAL=$(aws ecs list-tags-for-resource --resource-arn "$ARN" --query "tags[?key=='Name'].value" --output text 2>/dev/null || echo "")
-              if [ "$TAG_VAL" = "$CLUSTER_TAG_INPUT" ]; then
-                RESOLVED="$ARN"
-                break
-              fi
-            done
-
-            if [ -z "$RESOLVED" ]; then
-              # Fallback searching using the resourcegroupstaggingapi
-              RESOLVED=$(aws resourcegroupstaggingapi get-resources \
-                --region "${{ inputs.aws_region }}" \
-                --resource-type-filters "ecs:cluster" \
-                --tag-filters "Key=Name,Values=$CLUSTER_TAG_INPUT" \
-                --query "ResourceTagMappingList[0].ResourceARN" \
-                --output text 2>/dev/null || echo "")
-            fi
-
-            if [ -z "$RESOLVED" ] || [ "$RESOLVED" = "None" ]; then
-              echo "Error: Could not find any ECS Cluster with tag Name=$CLUSTER_TAG_INPUT in region ${{ inputs.aws_region }}"
-              exit 1
-            fi
-
-            echo "Resolved ECS cluster ARN: $RESOLVED"
-            echo "resolved_cluster=$RESOLVED" >> $GITHUB_OUTPUT
-          else
-            echo "Error: Neither ecs_cluster nor ecs_cluster_name_tag input was provided."
-            exit 1
-          fi
-
-      - name: Fetch Services
-        id: fetch
-        run: |
-          RESOLVED_CLUSTER="${{ steps.resolve-cluster.outputs.resolved_cluster }}"
-          if ! SERVICES_ARNS=$(aws ecs list-services --cluster "$RESOLVED_CLUSTER" --query "serviceArns" --output text 2>&1); then
-            echo "Failed to fetch services:"
-            exit 1
-          fi
-
-          echo "Service arns: $SERVICES_ARNS"
-
-          ALL_SERVICES="[]"
-          EXCLUDED_SERVICES="[]"
-          for ARN in $SERVICES_ARNS; do
-            ALL_SERVICES=$(echo "$ALL_SERVICES" | jq --arg arn "$ARN" '. + [$arn]')
-            EXCLUDE=false
-            FORCE_EXCLUDE=false
-            if [ -n "${{ inputs.exclude_tag_key }}" ]; then
-              TAG_VALUE=$(aws ecs list-tags-for-resource --resource-arn "$ARN" --query "tags[?key=='${{ inputs.exclude_tag_key }}'].value" --output text 2>/dev/null || echo "")
-
-              if [ -n "${{ inputs.exclude_tag_value }}" ]; then
-                if [ "$TAG_VALUE" == "${{ inputs.exclude_tag_value }}" ]; then
-                  EXCLUDE=true
-                fi
-              elif [ -n "$TAG_VALUE" ]; then
-                EXCLUDE=true
-              fi
-            fi
-
-            if [ -n "${{ inputs.always_exclude_tag_key }}" ]; then
-              ALWAYS_EXCLUDE_TAG_VALUE=$(aws ecs list-tags-for-resource --resource-arn "$ARN" --query "tags[?key=='${{ inputs.always_exclude_tag_key }}'].value" --output text 2>/dev/null || echo "")
-              if [ -n "$ALWAYS_EXCLUDE_TAG_VALUE" ]; then
-                FORCE_EXCLUDE=true
-              fi
-            fi
-
-            if [ "$FORCE_EXCLUDE" = true ] || { [ "$EXCLUDE" = true ] && [ "${{ inputs.force_release }}" != "Yes" ]; }; then
-              if [ "$FORCE_EXCLUDE" = true ]; then
-                echo "Excluding service $ARN based on always-exclude tag filter."
-              else
-                echo "Excluding service $ARN based on tag filter."
-              fi
-              EXCLUDED_SERVICES=$(echo "$EXCLUDED_SERVICES" | jq --arg arn "$ARN" '. + [$arn]')
-            fi
-          done
-
-          # Convert to single-line JSON array to avoid multiline GitHub Actions output errors
-          COMPACT_ALL=$(echo "$ALL_SERVICES" | jq -c '.')
-          COMPACT_EXCLUDED=$(echo "$EXCLUDED_SERVICES" | jq -c '.')
-          echo "services=$COMPACT_ALL" >> $GITHUB_OUTPUT
-          echo "excluded_services=$COMPACT_EXCLUDED" >> $GITHUB_OUTPUT
+    uses: ./.github/workflows/_aws_get_ecs_services.yaml
+    with:
+      environment: ${{ inputs.environment }}
+      aws_account_id: ${{ inputs.aws_account_id }}
+      aws_region: ${{ inputs.aws_region }}
+      ecs_cluster: ${{ inputs.ecs_cluster }}
+      ecs_cluster_name_tag: ${{ inputs.ecs_cluster_name_tag }}
+      exclude_tag_key: ${{ inputs.exclude_tag_key }}
+      exclude_tag_value: ${{ inputs.exclude_tag_value }}
+      always_exclude_tag_key: ${{ inputs.always_exclude_tag_key }}
+      force_release: ${{ inputs.force_release }}
+    secrets: inherit
 
   deploy:
     needs: get-services

--- a/.github/workflows/_aws_rollback_ecs_release.yaml
+++ b/.github/workflows/_aws_rollback_ecs_release.yaml
@@ -7,18 +7,39 @@ on:
         description: 'The environment being deployed to'
         required: true
         type: string
+      aws_account_id:
+        description: 'The AWS account ID of the cluster'
+        required: true
+        type: string
       aws_region:
         description: 'The AWS region of the cluster'
         required: true
         type: string
       ecs_cluster:
-        description: 'The ECS cluster'
-        required: true
+        description: 'The ECS cluster name or ARN to rollback (optional if ecs_cluster_name_tag is provided). Supports {aws_region}, {region}, and {environment} template replacements. If a plain name is provided, the full ARN will be constructed using aws_account_id and aws_region.'
+        required: false
         type: string
-      ecs_services:
-        description: 'JSON stringified array of ECS services to rollback'
-        required: true
+      ecs_cluster_name_tag:
+        description: 'The ECS cluster Name tag to search for (optional if ecs_cluster is provided). Supports {region} and {environment} template replacements.'
+        required: false
         type: string
+      exclude_tag_key:
+        description: 'The tag key used to filter out services (e.g. ExcludeFromRelease)'
+        required: false
+        type: string
+      exclude_tag_value:
+        description: 'The tag value used to filter out services (e.g. true)'
+        required: false
+        type: string
+      always_exclude_tag_key:
+        description: 'The tag key used to always filter out services (e.g. AlwaysExcludeFromRelease)'
+        required: false
+        type: string
+      force_release:
+        description: 'Force rollback even if the service is marked with the ExcludeFromRelease tag'
+        required: false
+        type: string
+        default: 'No'
       rollback_task_definition_arns:
         description: 'Optional JSON object map of service->taskDefinitionArn to rollback to. If not provided for a service, rollback_revisions is used to resolve the target revision.'
         required: false
@@ -44,7 +65,23 @@ permissions:
   contents: read
 
 jobs:
+  get-services:
+    uses: ./.github/workflows/_aws_get_ecs_services.yaml
+    with:
+      environment: ${{ inputs.environment }}
+      aws_account_id: ${{ inputs.aws_account_id }}
+      aws_region: ${{ inputs.aws_region }}
+      ecs_cluster: ${{ inputs.ecs_cluster }}
+      ecs_cluster_name_tag: ${{ inputs.ecs_cluster_name_tag }}
+      exclude_tag_key: ${{ inputs.exclude_tag_key }}
+      exclude_tag_value: ${{ inputs.exclude_tag_value }}
+      always_exclude_tag_key: ${{ inputs.always_exclude_tag_key }}
+      force_release: ${{ inputs.force_release }}
+    secrets: inherit
+
   rollback:
+    needs: get-services
+    if: ${{ needs.get-services.outputs.services != '[]' && needs.get-services.outputs.services != '' }}
     runs-on: ${{ vars.DEFAULT_RUNNER }}
     environment: ${{ inputs.environment }}
     outputs:
@@ -59,10 +96,11 @@ jobs:
       - name: Rollback ECS Services
         id: rollback-services
         run: |
-          SERVICES_JSON='${{ inputs.ecs_services }}'
+          SERVICES_JSON='${{ needs.get-services.outputs.services }}'
+          EXCLUDED_JSON='${{ needs.get-services.outputs.excluded_services }}'
           ROLLBACK_MAP_JSON='${{ inputs.rollback_task_definition_arns }}'
           ROLLBACK_REVISIONS='${{ inputs.rollback_revisions }}'
-          CLUSTER='${{ inputs.ecs_cluster }}'
+          CLUSTER='${{ needs.get-services.outputs.resolved_cluster }}'
           WAIT_FOR_STABLE='${{ inputs.wait_for_stable }}'
 
           if ! echo "$SERVICES_JSON" | jq -e 'type == "array"' >/dev/null 2>&1; then
@@ -93,6 +131,16 @@ jobs:
             local SERVICE="$1"
 
             echo "=== Rolling back service: $SERVICE ==="
+
+            IS_EXCLUDED=false
+            if echo "$EXCLUDED_JSON" | jq -e --arg svc "$SERVICE" '. | contains([$svc])' >/dev/null 2>&1; then
+              IS_EXCLUDED=true
+            fi
+
+            if [ "$IS_EXCLUDED" = "true" ]; then
+              echo "Skipping rollback for service $SERVICE due to exclusion filters."
+              return 0
+            fi
 
             TARGET_TASK_DEF=$(echo "$ROLLBACK_MAP_JSON" | jq -r --arg svc "$SERVICE" '.[$svc] // empty')
 

--- a/.github/workflows/_aws_rollback_ecs_release.yaml
+++ b/.github/workflows/_aws_rollback_ecs_release.yaml
@@ -1,0 +1,182 @@
+name: Rollback ECS Release
+
+on:
+  workflow_call:
+    inputs:
+      environment:
+        description: 'The environment being deployed to'
+        required: true
+        type: string
+      aws_region:
+        description: 'The AWS region of the cluster'
+        required: true
+        type: string
+      ecs_cluster:
+        description: 'The ECS cluster'
+        required: true
+        type: string
+      ecs_services:
+        description: 'JSON stringified array of ECS services to rollback'
+        required: true
+        type: string
+      rollback_task_definition_arns:
+        description: 'Optional JSON object map of service->taskDefinitionArn to rollback to. If not provided for a service, rollback_revisions is used to resolve the target revision.'
+        required: false
+        type: string
+        default: '{}'
+      rollback_revisions:
+        description: 'Number of task definition revisions to roll back when rollback_task_definition_arns is not provided for a service.'
+        required: false
+        type: number
+        default: 1
+      wait_for_stable:
+        description: 'Whether to wait for ECS services to become stable after rollback'
+        required: false
+        type: boolean
+        default: true
+    outputs:
+      rolled_back_task_definition_arns:
+        description: 'JSON stringified object map of service->rolled back task definition ARN'
+        value: ${{ jobs.rollback.outputs.rolled_back_task_definition_arns }}
+
+permissions:
+  id-token: write
+  contents: read
+
+jobs:
+  rollback:
+    runs-on: ${{ vars.DEFAULT_RUNNER }}
+    environment: ${{ inputs.environment }}
+    outputs:
+      rolled_back_task_definition_arns: ${{ steps.rollback-services.outputs.rolled_back_task_definition_arns }}
+    steps:
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v6
+        with:
+          aws-region: ${{ inputs.aws_region }}
+          role-to-assume: ${{ secrets.AWS_ROLE }}
+
+      - name: Rollback ECS Services
+        id: rollback-services
+        run: |
+          SERVICES_JSON='${{ inputs.ecs_services }}'
+          ROLLBACK_MAP_JSON='${{ inputs.rollback_task_definition_arns }}'
+          ROLLBACK_REVISIONS='${{ inputs.rollback_revisions }}'
+          CLUSTER='${{ inputs.ecs_cluster }}'
+          WAIT_FOR_STABLE='${{ inputs.wait_for_stable }}'
+
+          if ! echo "$SERVICES_JSON" | jq -e 'type == "array"' >/dev/null 2>&1; then
+            echo "Error: ecs_services must be a valid JSON array."
+            exit 1
+          fi
+
+          if ! echo "$ROLLBACK_MAP_JSON" | jq -e 'type == "object"' >/dev/null 2>&1; then
+            echo "Error: rollback_task_definition_arns must be a valid JSON object map."
+            exit 1
+          fi
+
+          if ! echo "$ROLLBACK_REVISIONS" | grep -Eq '^[0-9]+$'; then
+            echo "Error: rollback_revisions must be a positive integer."
+            exit 1
+          fi
+
+          if [ "$ROLLBACK_REVISIONS" -lt 1 ]; then
+            echo "Error: rollback_revisions must be greater than or equal to 1."
+            exit 1
+          fi
+
+          TMP_DIR=$(mktemp -d)
+          OUTPUT_FILE="$TMP_DIR/rollback_outputs.txt"
+          touch "$OUTPUT_FILE"
+
+          rollback_single_service() {
+            local SERVICE="$1"
+
+            echo "=== Rolling back service: $SERVICE ==="
+
+            TARGET_TASK_DEF=$(echo "$ROLLBACK_MAP_JSON" | jq -r --arg svc "$SERVICE" '.[$svc] // empty')
+
+            CURRENT_TASK_DEF=$(aws ecs describe-services \
+              --cluster "$CLUSTER" \
+              --services "$SERVICE" \
+              --query 'services[0].taskDefinition' \
+              --output text)
+
+            if [ -z "$CURRENT_TASK_DEF" ] || [ "$CURRENT_TASK_DEF" = "None" ]; then
+              echo "Error: Could not retrieve current task definition for service $SERVICE"
+              return 1
+            fi
+
+            if [ -z "$TARGET_TASK_DEF" ]; then
+              FAMILY_NAME=$(echo "$CURRENT_TASK_DEF" | awk -F'/' '{print $2}' | cut -d':' -f1)
+              if [ -z "$FAMILY_NAME" ]; then
+                echo "Error: Could not resolve task definition family from $CURRENT_TASK_DEF"
+                return 1
+              fi
+
+              TASK_DEFS_JSON=$(aws ecs list-task-definitions \
+                --family-prefix "$FAMILY_NAME" \
+                --status ACTIVE \
+                --sort DESC \
+                --query 'taskDefinitionArns' \
+                --output json)
+
+              TARGET_TASK_DEF=$(echo "$TASK_DEFS_JSON" | jq -r --arg current "$CURRENT_TASK_DEF" --argjson steps "$ROLLBACK_REVISIONS" '
+                . as $defs |
+                (index($current)) as $idx |
+                if $idx == null then
+                  (if ($defs | length) > $steps then $defs[$steps] else empty end)
+                else
+                  (if ($defs | length) > ($idx + $steps) then $defs[$idx + $steps] else empty end)
+                end
+              ')
+
+              if [ -z "$TARGET_TASK_DEF" ]; then
+                echo "Error: Could not resolve rollback target for service $SERVICE using rollback_revisions=$ROLLBACK_REVISIONS (current: $CURRENT_TASK_DEF)."
+                return 1
+              fi
+
+              echo "Auto-resolved rollback target for $SERVICE using rollback_revisions=$ROLLBACK_REVISIONS: $TARGET_TASK_DEF"
+            else
+              echo "Using provided rollback target for $SERVICE: $TARGET_TASK_DEF"
+            fi
+
+            if [ "$TARGET_TASK_DEF" = "$CURRENT_TASK_DEF" ]; then
+              echo "Service $SERVICE is already on target task definition; skipping update."
+              echo "$SERVICE=$TARGET_TASK_DEF" >> "$OUTPUT_FILE"
+              return 0
+            fi
+
+            aws ecs update-service \
+              --cluster "$CLUSTER" \
+              --service "$SERVICE" \
+              --task-definition "$TARGET_TASK_DEF"
+
+            if [ "$WAIT_FOR_STABLE" = "true" ]; then
+              echo "Waiting for service $SERVICE to become stable..."
+              aws ecs wait services-stable \
+                --cluster "$CLUSTER" \
+                --services "$SERVICE"
+              echo "Service $SERVICE is stable."
+            fi
+
+            echo "$SERVICE=$TARGET_TASK_DEF" >> "$OUTPUT_FILE"
+          }
+
+          FAILURES=0
+          for SERVICE in $(echo "$SERVICES_JSON" | jq -r '.[]'); do
+            rollback_single_service "$SERVICE" || FAILURES=$((FAILURES + 1))
+          done
+
+          if [ $FAILURES -gt 0 ]; then
+            echo "Error: $FAILURES service rollback(s) failed."
+            exit 1
+          fi
+
+          ROLLED_BACK_JSON="{}"
+          if [ -s "$OUTPUT_FILE" ]; then
+            ROLLED_BACK_JSON=$(jq -n -R '[inputs | split("=")] | map({key: .[0], value: .[1]}) | from_entries' "$OUTPUT_FILE")
+          fi
+
+          COMPACT_ROLLED_BACK=$(echo "$ROLLED_BACK_JSON" | jq -c '.')
+          echo "rolled_back_task_definition_arns=$COMPACT_ROLLED_BACK" >> $GITHUB_OUTPUT


### PR DESCRIPTION
## Issues, tasks, and related PRs
- https://github.com/SparkHire/spark-hire-com/pull/8938

## Summary
This pull request refactors the way ECS service discovery and filtering is performed in GitHub Actions workflows by introducing a reusable workflow for fetching ECS services, and updates dependent workflows to use this new approach. It also adds a new workflow for rolling back ECS releases with flexible task definition targeting and rollback logic.

**Reusable ECS Service Discovery and Filtering:**

* Introduced a new reusable workflow (`_aws_get_ecs_services.yaml`) that handles ECS cluster resolution (by name or tag), service listing, and exclusion logic based on tags and force flags. The workflow outputs the resolved cluster ARN, included and excluded service ARNs.

* Updated existing workflows (e.g., `_aws_perform_ecs_release.yaml`) to use the new reusable ECS service discovery workflow via the `uses` directive, removing duplicated logic and simplifying maintenance.

**New ECS Rollback Workflow:**

* Added a new workflow (`_aws_rollback_ecs_release.yaml`) to support rolling back ECS services. This workflow:
  - Uses the reusable ECS service discovery workflow to determine which services to operate on.
  - Supports rollback by specifying explicit task definition ARNs per service or by rolling back a configurable number of revisions.
  - Handles exclusion filters, waits for service stability if requested, and outputs the mapping of services to rolled-back task definition ARNs.

These changes improve modularity, reduce code duplication, and enable more robust and flexible ECS deployment and rollback processes across environments.

