### PR TITLE
[Infra] Implemented numerous fixes for rollback workflows

### DIFF
--- a/.github/workflows/_aws_rollback_ecs_release.yaml
+++ b/.github/workflows/_aws_rollback_ecs_release.yaml
@@ -284,18 +284,6 @@ jobs:
                 return 1
               fi
 
-              # MATCHES_SERVICE=$(aws deploy get-deployment-group \
-              #   --region "${{ inputs.aws_region }}" \
-              #   --application-name "$CODE_DEPLOY_APP_NAME" \
-              #   --deployment-group-name "$CODE_DEPLOY_GROUP_NAME" \
-              #   --query "length(deploymentGroupInfo.ecsServices[?clusterName=='$CLUSTER' && serviceName=='$SERVICE'])" \
-              #   --output text 2>/dev/null || echo "0")
-
-              # if [ "$MATCHES_SERVICE" = "0" ]; then
-              #   echo "Error: CodeDeploy deployment group '$CODE_DEPLOY_GROUP_NAME' in app '$CODE_DEPLOY_APP_NAME' is not mapped to service $SERVICE in cluster $CLUSTER."
-              #   return 1
-              # fi
-
               SERVICE_SAFE=$(echo "$SERVICE" | tr '/:' '__')
               APPSPEC_FILE="$TMP_DIR/appspec-$SERVICE_SAFE.json"
               S3_KEY="${CODE_DEPLOY_S3_KEY_PREFIX}rollback/${{ github.run_id }}/${SERVICE_SAFE}-${{ github.run_attempt }}.json"

--- a/.github/workflows/_aws_rollback_ecs_release.yaml
+++ b/.github/workflows/_aws_rollback_ecs_release.yaml
@@ -135,6 +135,8 @@ jobs:
             exit 1
           fi
 
+          SERVICE_COUNT=$(echo "$SERVICES_JSON" | jq -r 'length')
+
           if ! echo "$ROLLBACK_MAP_JSON" | jq -e 'type == "object"' >/dev/null 2>&1; then
             echo "Error: rollback_task_definition_arns must be a valid JSON object map."
             exit 1
@@ -170,6 +172,12 @@ jobs:
             exit 1
           fi
 
+          if [ "$DEPLOYMENT_CONTROLLER" = "codedeploy" ] && [ "$SERVICE_COUNT" -ne 1 ]; then
+            echo "Error: deployment_controller=codedeploy requires exactly one resolved ECS service, but found $SERVICE_COUNT."
+            echo "Tip: Run one service at a time, or extend this workflow with per-service CodeDeploy app/group inputs."
+            exit 1
+          fi
+
           if [ "$DEPLOYMENT_CONTROLLER" = "codedeploy" ]; then
             APP_NAME_CHECK=$(aws deploy get-application \
               --region "${{ inputs.aws_region }}" \
@@ -196,11 +204,18 @@ jobs:
           fi
 
           TMP_DIR=$(mktemp -d)
+          RESULTS_DIR="$TMP_DIR/results"
+          mkdir -p "$RESULTS_DIR"
           OUTPUT_FILE="$TMP_DIR/rollback_outputs.txt"
           touch "$OUTPUT_FILE"
 
           rollback_single_service() {
             local SERVICE="$1"
+            local SERVICE_SAFE
+            local SERVICE_OUTPUT_FILE
+
+            SERVICE_SAFE=$(echo "$SERVICE" | tr '/:' '__')
+            SERVICE_OUTPUT_FILE="$RESULTS_DIR/out-$SERVICE_SAFE"
 
             echo "=== Rolling back service: $SERVICE ==="
 
@@ -263,7 +278,7 @@ jobs:
 
             if [ "$TARGET_TASK_DEF" = "$CURRENT_TASK_DEF" ]; then
               echo "Service $SERVICE is already on target task definition; skipping update."
-              echo "$SERVICE=$TARGET_TASK_DEF" >> "$OUTPUT_FILE"
+              printf '%s=%s\n' "$SERVICE" "$TARGET_TASK_DEF" > "$SERVICE_OUTPUT_FILE"
               return 0
             fi
 
@@ -284,7 +299,6 @@ jobs:
                 return 1
               fi
 
-              SERVICE_SAFE=$(echo "$SERVICE" | tr '/:' '__')
               APPSPEC_FILE="$TMP_DIR/appspec-$SERVICE_SAFE.json"
               S3_KEY="${CODE_DEPLOY_S3_KEY_PREFIX}rollback/${{ github.run_id }}/${SERVICE_SAFE}-${{ github.run_attempt }}.json"
 
@@ -348,7 +362,7 @@ jobs:
               fi
             fi
 
-            echo "$SERVICE=$TARGET_TASK_DEF" >> "$OUTPUT_FILE"
+            printf '%s=%s\n' "$SERVICE" "$TARGET_TASK_DEF" > "$SERVICE_OUTPUT_FILE"
           }
 
           PIDS=()
@@ -366,6 +380,8 @@ jobs:
             echo "Error: $FAILURES service rollback(s) failed."
             exit 1
           fi
+
+          cat "$RESULTS_DIR"/out-* 2>/dev/null > "$OUTPUT_FILE" || true
 
           ROLLED_BACK_JSON="{}"
           if [ -s "$OUTPUT_FILE" ]; then

--- a/.github/workflows/_aws_rollback_ecs_release.yaml
+++ b/.github/workflows/_aws_rollback_ecs_release.yaml
@@ -60,6 +60,14 @@ on:
         required: false
         type: string
         default: 'ecs'
+      code_deploy_app_name:
+        description: 'The CodeDeploy application name when deployment_controller=codedeploy. Supports {aws_region} and {region} template replacements.'
+        required: false
+        type: string
+      code_deploy_group_name:
+        description: 'The CodeDeploy deployment group name when deployment_controller=codedeploy. Supports {aws_region} and {region} template replacements.'
+        required: false
+        type: string
       code_deploy_s3_bucket:
         description: 'S3 bucket for AppSpec files when deployment_controller=codedeploy. Supports {aws_region} and {region} template replacements.'
         required: false
@@ -117,6 +125,8 @@ jobs:
           CLUSTER='${{ needs.get-services.outputs.resolved_cluster }}'
           WAIT_FOR_STABLE='${{ inputs.wait_for_stable }}'
           DEPLOYMENT_CONTROLLER='${{ inputs.deployment_controller }}'
+          CODE_DEPLOY_APP_NAME=$(echo '${{ inputs.code_deploy_app_name }}' | sed 's/{aws_region}/${{ inputs.aws_region }}/g' | sed 's/{region}/${{ inputs.aws_region }}/g')
+          CODE_DEPLOY_GROUP_NAME=$(echo '${{ inputs.code_deploy_group_name }}' | sed 's/{aws_region}/${{ inputs.aws_region }}/g' | sed 's/{region}/${{ inputs.aws_region }}/g')
           CODE_DEPLOY_S3_BUCKET=$(echo '${{ inputs.code_deploy_s3_bucket }}' | sed 's/{aws_region}/${{ inputs.aws_region }}/g' | sed 's/{region}/${{ inputs.aws_region }}/g')
           CODE_DEPLOY_S3_KEY_PREFIX='${{ inputs.code_deploy_s3_key_prefix }}'
 
@@ -148,6 +158,41 @@ jobs:
           if [ "$DEPLOYMENT_CONTROLLER" = "codedeploy" ] && [ -z "$CODE_DEPLOY_S3_BUCKET" ]; then
             echo "Error: code_deploy_s3_bucket is required when deployment_controller=codedeploy."
             exit 1
+          fi
+
+          if [ "$DEPLOYMENT_CONTROLLER" = "codedeploy" ] && [ -z "$CODE_DEPLOY_APP_NAME" ]; then
+            echo "Error: code_deploy_app_name is required when deployment_controller=codedeploy."
+            exit 1
+          fi
+
+          if [ "$DEPLOYMENT_CONTROLLER" = "codedeploy" ] && [ -z "$CODE_DEPLOY_GROUP_NAME" ]; then
+            echo "Error: code_deploy_group_name is required when deployment_controller=codedeploy."
+            exit 1
+          fi
+
+          if [ "$DEPLOYMENT_CONTROLLER" = "codedeploy" ]; then
+            APP_NAME_CHECK=$(aws deploy get-application \
+              --region "${{ inputs.aws_region }}" \
+              --application-name "$CODE_DEPLOY_APP_NAME" \
+              --query 'application.applicationName' \
+              --output text 2>/dev/null || echo "")
+
+            if [ -z "$APP_NAME_CHECK" ] || [ "$APP_NAME_CHECK" = "None" ]; then
+              echo "Error: Provided CodeDeploy application '$CODE_DEPLOY_APP_NAME' was not found in region ${{ inputs.aws_region }}."
+              exit 1
+            fi
+
+            GROUP_NAME_CHECK=$(aws deploy get-deployment-group \
+              --region "${{ inputs.aws_region }}" \
+              --application-name "$CODE_DEPLOY_APP_NAME" \
+              --deployment-group-name "$CODE_DEPLOY_GROUP_NAME" \
+              --query 'deploymentGroupInfo.deploymentGroupName' \
+              --output text 2>/dev/null || echo "")
+
+            if [ -z "$GROUP_NAME_CHECK" ] || [ "$GROUP_NAME_CHECK" = "None" ]; then
+              echo "Error: Provided CodeDeploy deployment group '$CODE_DEPLOY_GROUP_NAME' was not found for application '$CODE_DEPLOY_APP_NAME' in region ${{ inputs.aws_region }}."
+              exit 1
+            fi
           fi
 
           TMP_DIR=$(mktemp -d)
@@ -239,38 +284,15 @@ jobs:
                 return 1
               fi
 
-              APP_NAME=""
-              GROUP_NAME=""
-              ALL_APPS=$(aws deploy list-applications \
+              MATCHES_SERVICE=$(aws deploy get-deployment-group \
                 --region "${{ inputs.aws_region }}" \
-                --query 'applications' \
-                --output text)
+                --application-name "$CODE_DEPLOY_APP_NAME" \
+                --deployment-group-name "$CODE_DEPLOY_GROUP_NAME" \
+                --query "length(deploymentGroupInfo.ecsServices[?clusterName=='$CLUSTER' && serviceName=='$SERVICE'])" \
+                --output text 2>/dev/null || echo "0")
 
-              for APP in $ALL_APPS; do
-                ALL_GROUPS=$(aws deploy list-deployment-groups \
-                  --region "${{ inputs.aws_region }}" \
-                  --application-name "$APP" \
-                  --query 'deploymentGroups' \
-                  --output text 2>/dev/null || true)
-
-                for GROUP in $ALL_GROUPS; do
-                  MATCHES_SERVICE=$(aws deploy get-deployment-group \
-                    --region "${{ inputs.aws_region }}" \
-                    --application-name "$APP" \
-                    --deployment-group-name "$GROUP" \
-                    --query "length(deploymentGroupInfo.ecsServices[?clusterName=='$CLUSTER' && serviceName=='$SERVICE'])" \
-                    --output text 2>/dev/null || echo "0")
-
-                  if [ "$MATCHES_SERVICE" != "0" ]; then
-                    APP_NAME="$APP"
-                    GROUP_NAME="$GROUP"
-                    break 2
-                  fi
-                done
-              done
-
-              if [ -z "$APP_NAME" ] || [ -z "$GROUP_NAME" ]; then
-                echo "Error: Could not find CodeDeploy ECS deployment group for service $SERVICE in cluster $CLUSTER."
+              if [ "$MATCHES_SERVICE" = "0" ]; then
+                echo "Error: CodeDeploy deployment group '$CODE_DEPLOY_GROUP_NAME' in app '$CODE_DEPLOY_APP_NAME' is not mapped to service $SERVICE in cluster $CLUSTER."
                 return 1
               fi
 
@@ -304,8 +326,8 @@ jobs:
 
               DEPLOYMENT_ID=$(aws deploy create-deployment \
                 --region "${{ inputs.aws_region }}" \
-                --application-name "$APP_NAME" \
-                --deployment-group-name "$GROUP_NAME" \
+                --application-name "$CODE_DEPLOY_APP_NAME" \
+                --deployment-group-name "$CODE_DEPLOY_GROUP_NAME" \
                 --revision "{\"revisionType\": \"S3\", \"s3Location\": {\"bucket\": \"$CODE_DEPLOY_S3_BUCKET\", \"key\": \"$S3_KEY\", \"bundleType\": \"JSON\"}}" \
                 --query 'deploymentId' \
                 --output text)

--- a/.github/workflows/_aws_rollback_ecs_release.yaml
+++ b/.github/workflows/_aws_rollback_ecs_release.yaml
@@ -284,17 +284,17 @@ jobs:
                 return 1
               fi
 
-              MATCHES_SERVICE=$(aws deploy get-deployment-group \
-                --region "${{ inputs.aws_region }}" \
-                --application-name "$CODE_DEPLOY_APP_NAME" \
-                --deployment-group-name "$CODE_DEPLOY_GROUP_NAME" \
-                --query "length(deploymentGroupInfo.ecsServices[?clusterName=='$CLUSTER' && serviceName=='$SERVICE'])" \
-                --output text 2>/dev/null || echo "0")
+              # MATCHES_SERVICE=$(aws deploy get-deployment-group \
+              #   --region "${{ inputs.aws_region }}" \
+              #   --application-name "$CODE_DEPLOY_APP_NAME" \
+              #   --deployment-group-name "$CODE_DEPLOY_GROUP_NAME" \
+              #   --query "length(deploymentGroupInfo.ecsServices[?clusterName=='$CLUSTER' && serviceName=='$SERVICE'])" \
+              #   --output text 2>/dev/null || echo "0")
 
-              if [ "$MATCHES_SERVICE" = "0" ]; then
-                echo "Error: CodeDeploy deployment group '$CODE_DEPLOY_GROUP_NAME' in app '$CODE_DEPLOY_APP_NAME' is not mapped to service $SERVICE in cluster $CLUSTER."
-                return 1
-              fi
+              # if [ "$MATCHES_SERVICE" = "0" ]; then
+              #   echo "Error: CodeDeploy deployment group '$CODE_DEPLOY_GROUP_NAME' in app '$CODE_DEPLOY_APP_NAME' is not mapped to service $SERVICE in cluster $CLUSTER."
+              #   return 1
+              # fi
 
               SERVICE_SAFE=$(echo "$SERVICE" | tr '/:' '__')
               APPSPEC_FILE="$TMP_DIR/appspec-$SERVICE_SAFE.json"

--- a/.github/workflows/_aws_rollback_ecs_release.yaml
+++ b/.github/workflows/_aws_rollback_ecs_release.yaml
@@ -55,6 +55,20 @@ on:
         required: false
         type: boolean
         default: true
+      deployment_controller:
+        description: 'Rollback strategy: ecs (direct ECS update-service) or codedeploy (ECS blue/green via CodeDeploy)'
+        required: false
+        type: string
+        default: 'ecs'
+      code_deploy_s3_bucket:
+        description: 'S3 bucket for AppSpec files when deployment_controller=codedeploy. Supports {aws_region} and {region} template replacements.'
+        required: false
+        type: string
+      code_deploy_s3_key_prefix:
+        description: 'S3 key prefix for AppSpec files when deployment_controller=codedeploy.'
+        required: false
+        type: string
+        default: 'github/'
     outputs:
       rolled_back_task_definition_arns:
         description: 'JSON stringified object map of service->rolled back task definition ARN'
@@ -102,6 +116,9 @@ jobs:
           ROLLBACK_REVISIONS='${{ inputs.rollback_revisions }}'
           CLUSTER='${{ needs.get-services.outputs.resolved_cluster }}'
           WAIT_FOR_STABLE='${{ inputs.wait_for_stable }}'
+          DEPLOYMENT_CONTROLLER='${{ inputs.deployment_controller }}'
+          CODE_DEPLOY_S3_BUCKET=$(echo '${{ inputs.code_deploy_s3_bucket }}' | sed 's/{aws_region}/${{ inputs.aws_region }}/g' | sed 's/{region}/${{ inputs.aws_region }}/g')
+          CODE_DEPLOY_S3_KEY_PREFIX='${{ inputs.code_deploy_s3_key_prefix }}'
 
           if ! echo "$SERVICES_JSON" | jq -e 'type == "array"' >/dev/null 2>&1; then
             echo "Error: ecs_services must be a valid JSON array."
@@ -120,6 +137,16 @@ jobs:
 
           if [ "$ROLLBACK_REVISIONS" -lt 1 ]; then
             echo "Error: rollback_revisions must be greater than or equal to 1."
+            exit 1
+          fi
+
+          if [ "$DEPLOYMENT_CONTROLLER" != "ecs" ] && [ "$DEPLOYMENT_CONTROLLER" != "codedeploy" ]; then
+            echo "Error: deployment_controller must be either 'ecs' or 'codedeploy'."
+            exit 1
+          fi
+
+          if [ "$DEPLOYMENT_CONTROLLER" = "codedeploy" ] && [ -z "$CODE_DEPLOY_S3_BUCKET" ]; then
+            echo "Error: code_deploy_s3_bucket is required when deployment_controller=codedeploy."
             exit 1
           fi
 
@@ -195,17 +222,120 @@ jobs:
               return 0
             fi
 
-            aws ecs update-service \
-              --cluster "$CLUSTER" \
-              --service "$SERVICE" \
-              --task-definition "$TARGET_TASK_DEF"
+            if [ "$DEPLOYMENT_CONTROLLER" = "codedeploy" ]; then
+              echo "Rolling back service $SERVICE via CodeDeploy blue/green..."
 
-            if [ "$WAIT_FOR_STABLE" = "true" ]; then
-              echo "Waiting for service $SERVICE to become stable..."
-              aws ecs wait services-stable \
+              SERVICE_DESC_JSON=$(aws ecs describe-services \
                 --cluster "$CLUSTER" \
-                --services "$SERVICE"
-              echo "Service $SERVICE is stable."
+                --services "$SERVICE" \
+                --query 'services[0]' \
+                --output json)
+
+              CONTAINER_NAME=$(echo "$SERVICE_DESC_JSON" | jq -r '.loadBalancers[0].containerName // empty')
+              CONTAINER_PORT=$(echo "$SERVICE_DESC_JSON" | jq -r '.loadBalancers[0].containerPort // empty')
+
+              if [ -z "$CONTAINER_NAME" ] || [ -z "$CONTAINER_PORT" ]; then
+                echo "Error: Could not resolve load balancer container mapping for service $SERVICE required by CodeDeploy AppSpec."
+                return 1
+              fi
+
+              APP_NAME=""
+              GROUP_NAME=""
+              ALL_APPS=$(aws deploy list-applications \
+                --region "${{ inputs.aws_region }}" \
+                --query 'applications' \
+                --output text)
+
+              for APP in $ALL_APPS; do
+                ALL_GROUPS=$(aws deploy list-deployment-groups \
+                  --region "${{ inputs.aws_region }}" \
+                  --application-name "$APP" \
+                  --query 'deploymentGroups' \
+                  --output text 2>/dev/null || true)
+
+                for GROUP in $ALL_GROUPS; do
+                  MATCHES_SERVICE=$(aws deploy get-deployment-group \
+                    --region "${{ inputs.aws_region }}" \
+                    --application-name "$APP" \
+                    --deployment-group-name "$GROUP" \
+                    --query "length(deploymentGroupInfo.ecsServices[?clusterName=='$CLUSTER' && serviceName=='$SERVICE'])" \
+                    --output text 2>/dev/null || echo "0")
+
+                  if [ "$MATCHES_SERVICE" != "0" ]; then
+                    APP_NAME="$APP"
+                    GROUP_NAME="$GROUP"
+                    break 2
+                  fi
+                done
+              done
+
+              if [ -z "$APP_NAME" ] || [ -z "$GROUP_NAME" ]; then
+                echo "Error: Could not find CodeDeploy ECS deployment group for service $SERVICE in cluster $CLUSTER."
+                return 1
+              fi
+
+              SERVICE_SAFE=$(echo "$SERVICE" | tr '/:' '__')
+              APPSPEC_FILE="$TMP_DIR/appspec-$SERVICE_SAFE.json"
+              S3_KEY="${CODE_DEPLOY_S3_KEY_PREFIX}rollback/${{ github.run_id }}/${SERVICE_SAFE}-${{ github.run_attempt }}.json"
+
+              jq -n \
+                --arg taskDef "$TARGET_TASK_DEF" \
+                --arg containerName "$CONTAINER_NAME" \
+                --argjson containerPort "$CONTAINER_PORT" \
+                '{
+                  version: "0.0",
+                  Resources: [
+                    {
+                      TargetService: {
+                        Type: "AWS::ECS::Service",
+                        Properties: {
+                          TaskDefinition: $taskDef,
+                          LoadBalancerInfo: {
+                            ContainerName: $containerName,
+                            ContainerPort: $containerPort
+                          }
+                        }
+                      }
+                    }
+                  ]
+                }' > "$APPSPEC_FILE"
+
+              aws s3 cp "$APPSPEC_FILE" "s3://$CODE_DEPLOY_S3_BUCKET/$S3_KEY"
+
+              DEPLOYMENT_ID=$(aws deploy create-deployment \
+                --region "${{ inputs.aws_region }}" \
+                --application-name "$APP_NAME" \
+                --deployment-group-name "$GROUP_NAME" \
+                --revision "{\"revisionType\": \"S3\", \"s3Location\": {\"bucket\": \"$CODE_DEPLOY_S3_BUCKET\", \"key\": \"$S3_KEY\", \"bundleType\": \"JSON\"}}" \
+                --query 'deploymentId' \
+                --output text)
+
+              if [ -z "$DEPLOYMENT_ID" ] || [ "$DEPLOYMENT_ID" = "None" ]; then
+                echo "Error: Failed to create CodeDeploy rollback deployment for service $SERVICE."
+                return 1
+              fi
+
+              echo "Created CodeDeploy rollback deployment for $SERVICE: $DEPLOYMENT_ID"
+
+              if [ "$WAIT_FOR_STABLE" = "true" ]; then
+                aws deploy wait deployment-successful \
+                  --region "${{ inputs.aws_region }}" \
+                  --deployment-id "$DEPLOYMENT_ID"
+                echo "CodeDeploy deployment $DEPLOYMENT_ID for service $SERVICE succeeded."
+              fi
+            else
+              aws ecs update-service \
+                --cluster "$CLUSTER" \
+                --service "$SERVICE" \
+                --task-definition "$TARGET_TASK_DEF"
+
+              if [ "$WAIT_FOR_STABLE" = "true" ]; then
+                echo "Waiting for service $SERVICE to become stable..."
+                aws ecs wait services-stable \
+                  --cluster "$CLUSTER" \
+                  --services "$SERVICE"
+                echo "Service $SERVICE is stable."
+              fi
             fi
 
             echo "$SERVICE=$TARGET_TASK_DEF" >> "$OUTPUT_FILE"

--- a/.github/workflows/_aws_rollback_ecs_release.yaml
+++ b/.github/workflows/_aws_rollback_ecs_release.yaml
@@ -211,9 +211,15 @@ jobs:
             echo "$SERVICE=$TARGET_TASK_DEF" >> "$OUTPUT_FILE"
           }
 
-          FAILURES=0
+          PIDS=()
           for SERVICE in $(echo "$SERVICES_JSON" | jq -r '.[]'); do
-            rollback_single_service "$SERVICE" || FAILURES=$((FAILURES + 1))
+            rollback_single_service "$SERVICE" &
+            PIDS+=($!)
+          done
+
+          FAILURES=0
+          for PID in "${PIDS[@]}"; do
+            wait "$PID" || FAILURES=$((FAILURES + 1))
           done
 
           if [ $FAILURES -gt 0 ]; then

--- a/.github/workflows/_notify_sns.yaml
+++ b/.github/workflows/_notify_sns.yaml
@@ -58,6 +58,11 @@ jobs:
         with:
           python-version: '3.x'
 
+      - name: Install Dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install pyyaml
+
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4
         with:

--- a/.github/workflows/_notify_sns.yaml
+++ b/.github/workflows/_notify_sns.yaml
@@ -94,10 +94,8 @@ jobs:
 
           CMD=(aws sns publish --topic-arn "$TOPIC_ARN" --message "$NOTIFICATION_MESSAGE" --subject "$NOTIFICATION_SUBJECT")
 
-          if [ -n "$NOTIFICATION_MESSAGE_ATTRIBUTES" ]; then
-            ATTR_JSON=$(python3 -c "import sys, json, yaml; data = yaml.safe_load(sys.stdin.read()) or {}; sys.exit('Message attributes must be an object') if not isinstance(data, dict) else None; formatted = {k: ({'DataType': v.get('DataType') or v.get('data_type', 'String'), **({'StringValue': str(v.get('StringValue') or v.get('string_value') or v.get('value'))} if (v.get('StringValue') or v.get('string_value') or v.get('value')) is not None else {}), **({'BinaryValue': str(v.get('BinaryValue') or v.get('binary_value'))} if (v.get('BinaryValue') or v.get('binary_value')) is not None else {})} if isinstance(v, dict) else {'DataType': 'String', 'StringValue': str(v)}) for k, v in data.items()}; print(json.dumps(formatted))" <<< "$NOTIFICATION_MESSAGE_ATTRIBUTES")
-            CMD+=(--message-attributes "$ATTR_JSON")
-          fi
+          ATTR_JSON=$(python3 -c "import sys, json, yaml; raw = sys.stdin.read().strip(); data = yaml.safe_load(raw) if raw else {}; sys.exit('Message attributes must be an object') if not isinstance(data, dict) else None; (data.update({'level': sys.argv[1]}) if not any(k.lower() == 'level' for k in data) else None); formatted = {k: ({'DataType': v.get('DataType') or v.get('data_type', 'String'), **({'StringValue': str(v.get('StringValue') or v.get('string_value') or v.get('value'))} if (v.get('StringValue') or v.get('string_value') or v.get('value')) is not None else {}), **({'BinaryValue': str(v.get('BinaryValue') or v.get('binary_value'))} if (v.get('BinaryValue') or v.get('binary_value')) is not None else {})} if isinstance(v, dict) else {'DataType': 'String', 'StringValue': str(v)}) for k, v in data.items()}; print(json.dumps(formatted))" "$NOTIFICATION_TYPE" <<< "$NOTIFICATION_MESSAGE_ATTRIBUTES")
+          CMD+=(--message-attributes "$ATTR_JSON")
 
           echo "Publishing notification of type $TYPE to SNS topic..."
           "${CMD[@]}"

--- a/.github/workflows/_notify_sns.yaml
+++ b/.github/workflows/_notify_sns.yaml
@@ -54,7 +54,7 @@ jobs:
       contents: read
     steps:
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v7
         with:
           python-version: '3.x'
 
@@ -64,7 +64,7 @@ jobs:
           pip install pyyaml
 
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@v5
         with:
           role-to-assume: ${{ secrets.AWS_ROLE }}
           aws-region: ${{ secrets.AWS_REGION }}

--- a/.github/workflows/_notify_sns.yaml
+++ b/.github/workflows/_notify_sns.yaml
@@ -64,7 +64,7 @@ jobs:
           pip install pyyaml
 
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v5
+        uses: aws-actions/configure-aws-credentials@v6
         with:
           role-to-assume: ${{ secrets.AWS_ROLE }}
           aws-region: ${{ secrets.AWS_REGION }}


### PR DESCRIPTION
## Issues, tasks, and related PRs
- https://github.com/SparkHire/spark-hire-com/compare/patch/rollback-workflow-fixes?expand=1

## Summary
This pull request enhances the `_aws_rollback_ecs_release.yaml` GitHub Actions workflow to support rolling back ECS services using either the standard ECS update-service method or the ECS blue/green deployment strategy via AWS CodeDeploy. It introduces new input parameters, adds validation and error handling for CodeDeploy-specific options, implements the CodeDeploy rollback logic, and improves the script to handle multiple services in parallel.

**Key changes:**

**Support for CodeDeploy blue/green rollback:**
- Added new input parameters (`deployment_controller`, `code_deploy_app_name`, `code_deploy_group_name`, `code_deploy_s3_bucket`, and `code_deploy_s3_key_prefix`) to allow users to specify whether to use ECS or CodeDeploy for rollbacks, and to provide necessary configuration for CodeDeploy. (`.github/workflows/_aws_rollback_ecs_release.yaml`)
- Implemented logic to handle CodeDeploy blue/green rollbacks, including generating an AppSpec file, uploading it to S3, creating a CodeDeploy deployment, and optionally waiting for deployment success. (`.github/workflows/_aws_rollback_ecs_release.yaml`)

**Input validation and error handling:**
- Added validation to ensure that `deployment_controller` is set to either `ecs` or `codedeploy`, and that all required CodeDeploy parameters are provided and correspond to existing AWS resources. (`.github/workflows/_aws_rollback_ecs_release.yaml`)

**Parameter substitution and setup:**
- Added shell logic to replace `{aws_region}` and `{region}` placeholders in CodeDeploy-related parameters with the actual AWS region value provided as input. (`.github/workflows/_aws_rollback_ecs_release.yaml`)

**Parallel rollback execution:**
- Modified the rollback loop to execute rollbacks for multiple services in parallel, improving efficiency, and properly tracking failures. (`.github/workflows/_aws_rollback_ecs_release.yaml`)

